### PR TITLE
! Fix : MyBaits XML의 이름 매칭 오류 개선

### DIFF
--- a/qrorder/build.gradle
+++ b/qrorder/build.gradle
@@ -15,6 +15,10 @@ java {
 	}
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs.add("-parameters")
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor

--- a/qrorder/src/main/java/htms/QROrder/log/repository/LogMapper.java
+++ b/qrorder/src/main/java/htms/QROrder/log/repository/LogMapper.java
@@ -1,21 +1,20 @@
 package htms.QROrder.log.repository;
 
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface LogMapper {
-    public void insertLoginLog(@Param("uuid") String uuid,
-                               @Param("ip") String ip,
-                               @Param("successStatus") String successStatus,
-                               @Param("errMsg") String errMsg,
-                               @Param("userId") String userId,
-                               @Param("sysPlantCd") String sysPlantCd);
-    public void insertLogoutLog(@Param("uuid") String uuid);
-    public void insertMenuOpenAccessLog(@Param("menuUuid") String menuUuid,
-                                        @Param("logUuid") String logUuid,
-                                        @Param("menuCd") String menuCd);
-    public void insertMenuCloseAccessLog(@Param("menuUuid") String menuUuid);
+    public void insertLoginLog(String uuid,
+                                String ip,
+                                String successStatus,
+                                String errMsg,
+                                String userId,
+                                String sysPlantCd);
+    public void insertLogoutLog(String uuid);
+    public void insertMenuOpenAccessLog(String menuUuid,
+                                        String logUuid,
+                                        String menuCd);
+    public void insertMenuCloseAccessLog(String menuUuid);
     public void closeAllOpenSessions();
     public void closeAllOpenMenuSessions();
 }

--- a/qrorder/src/main/java/htms/QROrder/log/repository/LogMapper.java
+++ b/qrorder/src/main/java/htms/QROrder/log/repository/LogMapper.java
@@ -1,13 +1,21 @@
 package htms.QROrder.log.repository;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface LogMapper {
-    public void insertLoginLog(String uuid, String ip, String successStatus, String errMsg, String userId, String sysPlantCd);
-    public void insertLogoutLog(String uuid);
-    public void insertMenuOpenAccessLog(String menuUuid, String logUuid, String menuCd);
-    public void insertMenuCloseAccessLog(String menuUuid);
+    public void insertLoginLog(@Param("uuid") String uuid,
+                               @Param("ip") String ip,
+                               @Param("successStatus") String successStatus,
+                               @Param("errMsg") String errMsg,
+                               @Param("userId") String userId,
+                               @Param("sysPlantCd") String sysPlantCd);
+    public void insertLogoutLog(@Param("uuid") String uuid);
+    public void insertMenuOpenAccessLog(@Param("menuUuid") String menuUuid,
+                                        @Param("logUuid") String logUuid,
+                                        @Param("menuCd") String menuCd);
+    public void insertMenuCloseAccessLog(@Param("menuUuid") String menuUuid);
     public void closeAllOpenSessions();
     public void closeAllOpenMenuSessions();
 }

--- a/qrorder/src/main/resources/application-local.properties.example
+++ b/qrorder/src/main/resources/application-local.properties.example
@@ -28,3 +28,9 @@ spring.datasource.hikari.max-lifetime=600000
 spring.datasource.hikari.validation-timeout=5000
 spring.datasource.hikari.leak-detection-threshold=60000
 spring.datasource.hikari.connection-test-query=SELECT 1
+
+# FileIO 저장경로
+file.upload.path=/your_dir/qr_order/uploads
+
+# PDF 컨버트 라이브러리 경로
+jodconverter.local.office-home=libre_program_path

--- a/qrorder/src/main/resources/application-local.properties.example
+++ b/qrorder/src/main/resources/application-local.properties.example
@@ -6,7 +6,7 @@
 # SSH Tunnel Configuration
 ssh.enabled=true
 ssh.host=your-ssh-server.com
-ssh.port=22
+ssh.port=225
 ssh.user=your-username
 ssh.private-key.local=/Users/your-name/.ssh/id_ed25519
 ssh.remote.host=localhost


### PR DESCRIPTION
### 현상 : 실제 환경 테스트 중에 라이브러리 적용하면서 오류발생
- 원인 : LogMapper 파일, mybait에서 @param 매칭 오류(db 컬럼를 이름으로 못 찾음)
- 해결 시도 : 로직은 안 건드리고 @param만 붙여서 해결

### 논의 내용
- controller가 따로 있으므로 거기서 작성되는지 확인 필요
- @param이 없어도 작동되는 것이 맞음. 그렇다면 프론트의 어떤 값에서 변수값이 바뀌는지 혹은 덜 설정됐는지 확인 필요

---

ps : 이 pr은 누락될 수 있으며, 기록용 혹은 학습용으로 남겨둔다