### PR TITLE
feat: 로그인/회원가입 API 예외 처리 및 사업자 진위확인 전환

### DIFF
--- a/qrorder/src/main/java/htms/QROrder/audit/controller/AuditController.java
+++ b/qrorder/src/main/java/htms/QROrder/audit/controller/AuditController.java
@@ -4,6 +4,7 @@ import htms.QROrder.audit.domain.TableInfo;
 import htms.QROrder.audit.service.AuditService;
 import htms.QROrder.audit.service.ErrorService;
 import htms.QROrder.auth.domain.Login;
+import htms.QROrder.auth.exception.BusinessRegiException;
 import htms.QROrder.common.dto.CommonResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -34,6 +35,14 @@ public class AuditController {
     @ExceptionHandler(RuntimeException.class)
     @ResponseBody
     public ResponseEntity<CommonResponse> handleException(RuntimeException e, HttpServletRequest request) {
+        if (e instanceof BusinessRegiException) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(CommonResponse.builder()
+                            .success(false)
+                            .message(e.getMessage())
+                            .build());
+        }
+
         HttpSession session = request.getSession(false);
 
         String menuCd = null;

--- a/qrorder/src/main/java/htms/QROrder/auth/service/SignUpService.java
+++ b/qrorder/src/main/java/htms/QROrder/auth/service/SignUpService.java
@@ -60,12 +60,31 @@ public class SignUpService {
         try {
             RestTemplate restTemplate = new RestTemplate();
 
-            String url = "https://api.odcloud.kr/api/nts-businessman/v1/status?serviceKey=" + ntsServiceKey;
+            String url = "https://api.odcloud.kr/api/nts-businessman/v1/validate?serviceKey=" + ntsServiceKey;
+
+            String businessRegiNum = signUpRequest.getBusinessRegiNum() == null
+                    ? ""
+                    : signUpRequest.getBusinessRegiNum().replaceAll("\\D", "");
+            String userNm = signUpRequest.getUserNm() == null
+                    ? ""
+                    : signUpRequest.getUserNm().trim();
+
+            if (businessRegiNum.length() != 10) {
+                throw new BusinessRegiException("사업자등록번호 10자리를 입력해주세요.");
+            }
+
+            if (signUpRequest.getBusinessRegiDate() == null) {
+                throw new BusinessRegiException("개업일을 입력해주세요.");
+            }
+
+            if (userNm.isEmpty()) {
+                throw new BusinessRegiException("대표자명을 입력해주세요.");
+            }
 
             Map<String, Object> business = new HashMap<>();
-            business.put("b_no", signUpRequest.getBusinessRegiNum());
+            business.put("b_no", businessRegiNum);
             business.put("start_dt", signUpRequest.getBusinessRegiDate().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd")));
-            business.put("p_nm", signUpRequest.getUserNm());
+            business.put("p_nm", userNm);
             business.put("p_nm2", "");
             business.put("b_nm", "");
             business.put("corp_no", "");

--- a/qrorder/src/main/java/htms/QROrder/config/WebConfig.java
+++ b/qrorder/src/main/java/htms/QROrder/config/WebConfig.java
@@ -23,6 +23,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(1)
                 .addPathPatterns("/api/**")
                 .excludePathPatterns("/api/auth/login",
+                        "/api/auth/signup/**",
+                        "/api/auth/email_valid/new_user/**",
+                        "/api/auth/email_valid/pwd_change/send",
+                        "/api/auth/email_valid/pwd_change",
+                        "/api/auth/pwd_change",
                         "/api/qr/**",
                         "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**");
 


### PR DESCRIPTION
## Summary
- 로그인/회원가입 관련 **API 예외 패턴** 추가
- 사업자번호 조회 → 진위확인 API로 변경 및 관련 로직 수정 (`/status`에서 `/validate`가 의도에 맞아 수정)
- 예외 처리가 가로채지는 현상 수정 (api 400에러를 500에러로 가로챔)

## Commits
- `7601a1b` feat : 로그인 및 회원가입 관련 api 예외 패턴 추가
- `9a55f08` feat : 조회 -> 진위확인 API변경 및 수정
- `7cec54b` feat : 예외 처리 가로채는 현상 수정

## backend의 체크 리스트
- [x] 로그인/회원가입 시 예외 응답 패턴 확인
- [ ] 사업자번호 진위확인 API 정상 호출 및 응답 검증
- [ ] 예외 발생 시 의도한 핸들러까지 도달하는지 확인

---
@seonhu22 PR 검토 부탁드립니다.