### PR TITLE
fix: 로그인 체크 인터셉터 관련 - 기존: session.getAttribute("loginUser")에서 userId, sysPlantCd 추출 → 로그인 전 NullPointerException 발생   - 변경: emailValidRequest.getUserId()와 "CHGPWD" 고정값 사용 → sendPwdChangeCode와 동일한 방식, 로그인 전 사용 가능

### DIFF
--- a/qrorder/src/main/java/htms/QROrder/auth/controller/EmailValidController.java
+++ b/qrorder/src/main/java/htms/QROrder/auth/controller/EmailValidController.java
@@ -1,6 +1,5 @@
 package htms.QROrder.auth.controller;
 
-import htms.QROrder.auth.domain.Login;
 import htms.QROrder.auth.dto.EmailValidRequest;
 import htms.QROrder.auth.exception.EmailValidException;
 import htms.QROrder.auth.service.EmailValidService;
@@ -83,9 +82,7 @@ public class EmailValidController {
         session.removeAttribute("pwdChangeEmail");
         session.removeAttribute("pwdChangeValidCode");
 
-        Login loginUser = (Login) session.getAttribute("loginUser");
-
-        String validCode = emailValidService.sendPwdChangeCode(emailValidRequest.getEmail(), loginUser.getUserId(), loginUser.getSysPlantCd());
+        String validCode = emailValidService.sendPwdChangeCode(emailValidRequest.getEmail(), emailValidRequest.getUserId(), "CHGPWD");
         session.setAttribute("pwdChangeEmail", emailValidRequest.getEmail());
         session.setAttribute("pwdChangeValidCode", validCode);
 

--- a/qrorder/src/main/java/htms/QROrder/config/WebConfig.java
+++ b/qrorder/src/main/java/htms/QROrder/config/WebConfig.java
@@ -23,6 +23,12 @@ public class WebConfig implements WebMvcConfigurer {
                 .order(1)
                 .addPathPatterns("/api/**")
                 .excludePathPatterns("/api/auth/login",
+                        "/api/auth/signup/**",
+                        "/api/auth/email_valid/new_user/**",
+                        "/api/auth/email_valid/pwd_change/send",
+                        "/api/auth/email_valid/pwd_change/re_send",
+                        "/api/auth/email_valid/pwd_change",
+                        "/api/auth/pwd_change",
                         "/api/qr/**",
                         "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**");
 


### PR DESCRIPTION
- 기존: session.getAttribute("loginUser")에서 userId, sysPlantCd 추출 → 로그인 전 NullPointerException 발생
    - 변경: emailValidRequest.getUserId()와 "CHGPWD" 고정값 사용 → sendPwdChangeCode와 동일한 방식, 로그인 전 사용 가능