### PR TITLE
fix: 로그인 체크 인터셉터 관련

### DIFF
--- a/qrorder/src/main/java/htms/QROrder/audit/controller/AuditController.java
+++ b/qrorder/src/main/java/htms/QROrder/audit/controller/AuditController.java
@@ -9,6 +9,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -19,6 +21,7 @@ import java.util.List;
 @Slf4j
 @Controller
 @ControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
 @RequiredArgsConstructor
 @RequestMapping("/api/audit")
 public class AuditController {

--- a/qrorder/src/main/java/htms/QROrder/auth/service/SignUpService.java
+++ b/qrorder/src/main/java/htms/QROrder/auth/service/SignUpService.java
@@ -57,15 +57,30 @@ public class SignUpService {
     }
 
     private boolean chkBusinessRegistrationNumberAPI(SignUpRequest signUpRequest) {
+        String businessRegiNum = signUpRequest.getBusinessRegiNum() == null
+                ? "" : signUpRequest.getBusinessRegiNum().replaceAll("\\D", "");
+        String userNm = signUpRequest.getUserNm() == null
+                ? "" : signUpRequest.getUserNm().trim();
+
+        if (businessRegiNum.length() != 10) {
+            throw new BusinessRegiException("사업자등록번호 10자리를 입력해주세요.");
+        }
+        if (signUpRequest.getBusinessRegiDate() == null) {
+            throw new BusinessRegiException("개업일을 입력해주세요.");
+        }
+        if (userNm.isEmpty()) {
+            throw new BusinessRegiException("대표자명을 입력해주세요.");
+        }
+
         try {
             RestTemplate restTemplate = new RestTemplate();
 
-            String url = "https://api.odcloud.kr/api/nts-businessman/v1/status?serviceKey=" + ntsServiceKey;
+            String url = "https://api.odcloud.kr/api/nts-businessman/v1/validate?serviceKey=" + ntsServiceKey;
 
             Map<String, Object> business = new HashMap<>();
-            business.put("b_no", signUpRequest.getBusinessRegiNum());
+            business.put("b_no", businessRegiNum);
             business.put("start_dt", signUpRequest.getBusinessRegiDate().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd")));
-            business.put("p_nm", signUpRequest.getUserNm());
+            business.put("p_nm", userNm);
             business.put("p_nm2", "");
             business.put("b_nm", "");
             business.put("corp_no", "");

--- a/qrorder/src/main/java/htms/QROrder/common/exception/GlobalExceptionHandler.java
+++ b/qrorder/src/main/java/htms/QROrder/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package htms.QROrder.common.exception;
 
 import htms.QROrder.auth.exception.BusinessRegiException;
+import htms.QROrder.auth.exception.EmailValidException;
 import htms.QROrder.auth.exception.LoginFailException;
 import htms.QROrder.common.dto.CommonResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<CommonResponse> handleValidationException(ValidationException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.<Void>builder()
+                        .success(false)
+                        .message(e.getMessage())
+                        .build()
+                );
+    }
+
+    @ExceptionHandler(EmailValidException.class)
+    public ResponseEntity<CommonResponse> handleEmailValidException(EmailValidException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.<Void>builder()
                         .success(false)


### PR DESCRIPTION
## 변경 사항

### 1. 사업자번호 진위확인 API 전환 (SignUpService.java)

**문제**
- 기존에 `/status` 엔드포인트를 사용하고 있어 사업자번호의 상태(폐업 여부)만
  확인되었고, 개업일·대표자명 검증이 실질적으로 이루어지지 않았습니다.

**변경**
- `/status` → `/validate` 엔드포인트 전환 (진위확인 API)
- 입력값 사전 검증 추가: 사업자번호 10자리 확인, 개업일 null 체크, 대표자명 빈값 체크
- 입력값 정제 추가: 사업자번호 숫자 추출(`replaceAll("\\D", "")`), 대표자명 trim

  ---

### 2. ExceptionHandler 우선순위 명시 (AuditController.java)

**문제**
- `AuditController`가 `@ControllerAdvice` + `@ExceptionHandler(RuntimeException.class)`를
  가지고 있어, `GlobalExceptionHandler`의 구체적인 예외 핸들러(`BusinessRegiException` 등)보다
  먼저 실행되는 경우가 발생했습니다.

**변경**
- `AuditController`에 `@Order(Ordered.LOWEST_PRECEDENCE)` 추가
- 이로써 `GlobalExceptionHandler`가 구체적 예외를 우선 처리하고,
  AuditController는 처리되지 않은 RuntimeException에만 작동합니다.

  ---

### 3. EmailValidException 400 핸들러 추가 (GlobalExceptionHandler.java)

**문제**
- `EmailValidException`(인증 코드 불일치, 이메일 인증 미완료 등)이
  `GlobalExceptionHandler`에 핸들러가 없어 `AuditController`의 RuntimeException 핸들러로
  처리되고 있었습니다. 결과적으로 사용자 실수가 500 응답 + 오류 DB 저장으로 처리되었습니다.

**변경**
- `EmailValidException` → 400 BAD_REQUEST 핸들러 추가
- 인증 관련 사용자 오류는 오류 로그에 저장되지 않고 400으로 응답합니다.